### PR TITLE
Allowing to have more than 9 slices

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -16,7 +16,7 @@ class Command extends \PHPUnit\TextUI\Command
     public function slicesHandler($slices)
     {
         $parts = [];
-        if (!preg_match('/^([0-9])+\/([0-9])+$/', $slices, $parts)) {
+        if (!preg_match('/^([0-9]+)\/([0-9]+)$/', $slices, $parts)) {
             echo '--slices: you must provide a value like 2/4 if you want to run the second slice on a total of 4';
             exit(1);
         }


### PR DESCRIPTION
`([0-9])+` will generate for the input 12 only one capture group with the result 2 (see https://regex101.com/r/OBD5sn/1 )  
`([0-9]+)` on the other hand gets the full number (see https://regex101.com/r/OBD5sn/2 )