### PR TITLE
Add type to $exit parameter

### DIFF
--- a/src/TestRunner.php
+++ b/src/TestRunner.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestSuite;
 
 class TestRunner extends \PHPUnit\TextUI\TestRunner
 {
-    public function doRun(Test $suite, array $arguments = [], $exit = true): TestResult
+    public function doRun(Test $suite, array $arguments = [], bool $exit = true): TestResult
     {
         if (isset($arguments['totalSlices'], $arguments['currentSlice']) && $suite instanceof TestSuite) {
             $localArguments = $arguments;


### PR DESCRIPTION
This fixes the following error in PHP 7.1:

> Fatal error: Uncaught Symfony\Component\Debug\Exception\ContextErrorException: Warning: Declaration of Wizaplace\PHPUnit\Slicer\TestRunner::doRun(PHPUnit\Framework\Test $suite, array $arguments = Array, $exit = true): PHPUnit\Framework\TestResult should be compatible with PHPUnit\TextUI\TestRunner::doRun(PHPUnit\Framework\Test $suite, array $arguments = Array, bool $exit = true): PHPUnit\Framework\TestResult in /var/www/html/vendor/wizaplace/phpunit-slicer/src/TestRunner.php:11