### PR TITLE
Do not extend `final class TestRunner` and just copy-and-paste its contents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1",
-        "phpunit/phpunit": "^7|^8|^9"
+        "phpunit/phpunit": "^7|^8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1",
-        "phpunit/phpunit": "^7|^8"
+        "phpunit/phpunit": "^7|^8|^9"
     },
     "autoload": {
         "psr-4": {

--- a/src/Command.php
+++ b/src/Command.php
@@ -4,13 +4,158 @@ declare(strict_types=1);
 
 namespace Wizaplace\PHPUnit\Slicer;
 
-class Command extends \PHPUnit\TextUI\Command
-{
-    public function __construct()
-    {
-        $this->longOptions['slices='] = 'slicesHandler';
+use PharIo\Manifest\ApplicationName;
+use PharIo\Manifest\Exception as ManifestException;
+use PharIo\Manifest\ManifestLoader;
+use PharIo\Version\Version as PharIoVersion;
+use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Runner\StandardTestSuiteLoader;
+use PHPUnit\Runner\TestSuiteLoader;
+use PHPUnit\Runner\TestSuiteSorter;
+use PHPUnit\Runner\Version;
+use PHPUnit\TextUI\Help;
+use PHPUnit\TextUI\ResultPrinter;
+use PHPUnit\TextUI\TestRunner;
+use PHPUnit\Util\Configuration;
+use PHPUnit\Util\ConfigurationGenerator;
+use PHPUnit\Util\FileLoader;
+use PHPUnit\Util\Filesystem;
+use PHPUnit\Util\Getopt;
+use PHPUnit\Util\Log\TeamCity;
+use PHPUnit\Util\Printer;
+use PHPUnit\Util\TestDox\CliTestDoxPrinter;
+use PHPUnit\Util\TextTestListRenderer;
+use PHPUnit\Util\XmlTestListRenderer;
+use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
 
-        // there is no parent construct
+use Throwable;
+
+/**
+ * A TestRunner for the Command Line Interface (CLI)
+ * PHP SAPI Module.
+ */
+class Command
+{
+    /**
+     * @var array<string,mixed>
+     */
+    protected $arguments = [
+        'listGroups'              => false,
+        'listSuites'              => false,
+        'listTests'               => false,
+        'listTestsXml'            => false,
+        'loader'                  => null,
+        'useDefaultConfiguration' => true,
+        'loadedExtensions'        => [],
+        'notLoadedExtensions'     => [],
+        'warnings'                => [],
+    ];
+
+    /**
+     * @var array<string,mixed>
+     */
+    protected $options = [];
+
+    /**
+     * @var array<string,mixed>
+     */
+    protected $longOptions = [
+        'slices='                   => 'slicesHandler',
+        'atleast-version='          => null,
+        'prepend='                  => null,
+        'bootstrap='                => null,
+        'cache-result'              => null,
+        'do-not-cache-result'       => null,
+        'cache-result-file='        => null,
+        'check-version'             => null,
+        'colors=='                  => null,
+        'columns='                  => null,
+        'configuration='            => null,
+        'coverage-clover='          => null,
+        'coverage-crap4j='          => null,
+        'coverage-html='            => null,
+        'coverage-php='             => null,
+        'coverage-text=='           => null,
+        'coverage-xml='             => null,
+        'debug'                     => null,
+        'disallow-test-output'      => null,
+        'disallow-resource-usage'   => null,
+        'disallow-todo-tests'       => null,
+        'default-time-limit='       => null,
+        'enforce-time-limit'        => null,
+        'exclude-group='            => null,
+        'filter='                   => null,
+        'generate-configuration'    => null,
+        'globals-backup'            => null,
+        'group='                    => null,
+        'help'                      => null,
+        'resolve-dependencies'      => null,
+        'ignore-dependencies'       => null,
+        'include-path='             => null,
+        'list-groups'               => null,
+        'list-suites'               => null,
+        'list-tests'                => null,
+        'list-tests-xml='           => null,
+        'loader='                   => null,
+        'log-junit='                => null,
+        'log-teamcity='             => null,
+        'no-configuration'          => null,
+        'no-coverage'               => null,
+        'no-logging'                => null,
+        'no-interaction'            => null,
+        'no-extensions'             => null,
+        'order-by='                 => null,
+        'printer='                  => null,
+        'process-isolation'         => null,
+        'repeat='                   => null,
+        'dont-report-useless-tests' => null,
+        'random-order'              => null,
+        'random-order-seed='        => null,
+        'reverse-order'             => null,
+        'reverse-list'              => null,
+        'static-backup'             => null,
+        'stderr'                    => null,
+        'stop-on-defect'            => null,
+        'stop-on-error'             => null,
+        'stop-on-failure'           => null,
+        'stop-on-warning'           => null,
+        'stop-on-incomplete'        => null,
+        'stop-on-risky'             => null,
+        'stop-on-skipped'           => null,
+        'fail-on-warning'           => null,
+        'fail-on-risky'             => null,
+        'strict-coverage'           => null,
+        'disable-coverage-ignore'   => null,
+        'strict-global-state'       => null,
+        'teamcity'                  => null,
+        'testdox'                   => null,
+        'testdox-group='            => null,
+        'testdox-exclude-group='    => null,
+        'testdox-html='             => null,
+        'testdox-text='             => null,
+        'testdox-xml='              => null,
+        'test-suffix='              => null,
+        'testsuite='                => null,
+        'verbose'                   => null,
+        'version'                   => null,
+        'whitelist='                => null,
+        'dump-xdebug-filter='       => null,
+    ];
+
+    /**
+     * @var bool
+     */
+    private $versionStringPrinted = false;
+
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     */
+    public static function main(bool $exit = true): int
+    {
+        return (new static)->run($_SERVER['argv'], $exit);
     }
 
     public function slicesHandler($slices)
@@ -38,10 +183,964 @@ class Command extends \PHPUnit\TextUI\Command
         $this->arguments['totalSlices'] = $totalSlices;
     }
 
+    /**
+     * @throws Exception
+     */
+    public function run(array $argv, bool $exit = true): int
+    {
+        $this->handleArguments($argv);
+
+        $runner = $this->createRunner();
+
+        if ($this->arguments['test'] instanceof Test) {
+            $suite = $this->arguments['test'];
+        } else {
+            $suite = $runner->getTest(
+                $this->arguments['test'],
+                $this->arguments['testFile'],
+                $this->arguments['testSuffixes']
+            );
+        }
+
+        if ($this->arguments['listGroups']) {
+            return $this->handleListGroups($suite, $exit);
+        }
+
+        if ($this->arguments['listSuites']) {
+            return $this->handleListSuites($exit);
+        }
+
+        if ($this->arguments['listTests']) {
+            return $this->handleListTests($suite, $exit);
+        }
+
+        if ($this->arguments['listTestsXml']) {
+            return $this->handleListTestsXml($suite, $this->arguments['listTestsXml'], $exit);
+        }
+
+        unset($this->arguments['test'], $this->arguments['testFile']);
+
+        try {
+            $result = $runner->doRun($suite, $this->arguments, $exit);
+        } catch (Exception $e) {
+            print $e->getMessage() . \PHP_EOL;
+        }
+
+        $return = TestRunner::FAILURE_EXIT;
+
+        if (isset($result) && $result->wasSuccessful()) {
+            $return = TestRunner::SUCCESS_EXIT;
+        } elseif (!isset($result) || $result->errorCount() > 0) {
+            $return = TestRunner::EXCEPTION_EXIT;
+        }
+
+        if ($exit) {
+            exit($return);
+        }
+
+        return $return;
+    }
+
+    /**
+     * Create a TestRunner, override in subclasses.
+     */
+    protected function createRunner(): \Wizaplace\PHPUnit\Slicer\TestRunner
+    {
+        return new \Wizaplace\PHPUnit\Slicer\TestRunner($this->arguments['loader']);
+    }
+
+    /**
+     * Handles the command-line arguments.
+     *
+     * A child class of PHPUnit\TextUI\Command can hook into the argument
+     * parsing by adding the switch(es) to the $longOptions array and point to a
+     * callback method that handles the switch(es) in the child class like this
+     *
+     * <code>
+     * <?php
+     * class MyCommand extends PHPUnit\TextUI\Command
+     * {
+     *     public function __construct()
+     *     {
+     *         // my-switch won't accept a value, it's an on/off
+     *         $this->longOptions['my-switch'] = 'myHandler';
+     *         // my-secondswitch will accept a value - note the equals sign
+     *         $this->longOptions['my-secondswitch='] = 'myOtherHandler';
+     *     }
+     *
+     *     // --my-switch  -> myHandler()
+     *     protected function myHandler()
+     *     {
+     *     }
+     *
+     *     // --my-secondswitch foo -> myOtherHandler('foo')
+     *     protected function myOtherHandler ($value)
+     *     {
+     *     }
+     *
+     *     // You will also need this - the static keyword in the
+     *     // PHPUnit\TextUI\Command will mean that it'll be
+     *     // PHPUnit\TextUI\Command that gets instantiated,
+     *     // not MyCommand
+     *     public static function main($exit = true)
+     *     {
+     *         $command = new static;
+     *
+     *         return $command->run($_SERVER['argv'], $exit);
+     *     }
+     *
+     * }
+     * </code>
+     *
+     * @throws Exception
+     */
+    protected function handleArguments(array $argv): void
+    {
+        try {
+            $this->options = Getopt::getopt(
+                $argv,
+                'd:c:hv',
+                \array_keys($this->longOptions)
+            );
+        } catch (Exception $t) {
+            $this->exitWithErrorMessage($t->getMessage());
+        }
+
+        foreach ($this->options[0] as $option) {
+            switch ($option[0]) {
+                case '--colors':
+                    $this->arguments['colors'] = $option[1] ?: ResultPrinter::COLOR_AUTO;
+
+                    break;
+
+                case '--bootstrap':
+                    $this->arguments['bootstrap'] = $option[1];
+
+                    break;
+
+                case '--cache-result':
+                    $this->arguments['cacheResult'] = true;
+
+                    break;
+
+                case '--do-not-cache-result':
+                    $this->arguments['cacheResult'] = false;
+
+                    break;
+
+                case '--cache-result-file':
+                    $this->arguments['cacheResultFile'] = $option[1];
+
+                    break;
+
+                case '--columns':
+                    if (\is_numeric($option[1])) {
+                        $this->arguments['columns'] = (int) $option[1];
+                    } elseif ($option[1] === 'max') {
+                        $this->arguments['columns'] = 'max';
+                    }
+
+                    break;
+
+                case 'c':
+                case '--configuration':
+                    $this->arguments['configuration'] = $option[1];
+
+                    break;
+
+                case '--coverage-clover':
+                    $this->arguments['coverageClover'] = $option[1];
+
+                    break;
+
+                case '--coverage-crap4j':
+                    $this->arguments['coverageCrap4J'] = $option[1];
+
+                    break;
+
+                case '--coverage-html':
+                    $this->arguments['coverageHtml'] = $option[1];
+
+                    break;
+
+                case '--coverage-php':
+                    $this->arguments['coveragePHP'] = $option[1];
+
+                    break;
+
+                case '--coverage-text':
+                    if ($option[1] === null) {
+                        $option[1] = 'php://stdout';
+                    }
+
+                    $this->arguments['coverageText']                   = $option[1];
+                    $this->arguments['coverageTextShowUncoveredFiles'] = false;
+                    $this->arguments['coverageTextShowOnlySummary']    = false;
+
+                    break;
+
+                case '--coverage-xml':
+                    $this->arguments['coverageXml'] = $option[1];
+
+                    break;
+
+                case 'd':
+                    $ini = \explode('=', $option[1]);
+
+                    if (isset($ini[0])) {
+                        if (isset($ini[1])) {
+                            \ini_set($ini[0], $ini[1]);
+                        } else {
+                            \ini_set($ini[0], '1');
+                        }
+                    }
+
+                    break;
+
+                case '--debug':
+                    $this->arguments['debug'] = true;
+
+                    break;
+
+                case 'h':
+                case '--help':
+                    $this->showHelp();
+                    exit(TestRunner::SUCCESS_EXIT);
+
+                    break;
+
+                case '--filter':
+                    $this->arguments['filter'] = $option[1];
+
+                    break;
+
+                case '--testsuite':
+                    $this->arguments['testsuite'] = $option[1];
+
+                    break;
+
+                case '--generate-configuration':
+                    $this->printVersionString();
+
+                    print 'Generating phpunit.xml in ' . \getcwd() . \PHP_EOL . \PHP_EOL;
+
+                    print 'Bootstrap script (relative to path shown above; default: vendor/autoload.php): ';
+                    $bootstrapScript = \trim(\fgets(\STDIN));
+
+                    print 'Tests directory (relative to path shown above; default: tests): ';
+                    $testsDirectory = \trim(\fgets(\STDIN));
+
+                    print 'Source directory (relative to path shown above; default: src): ';
+                    $src = \trim(\fgets(\STDIN));
+
+                    if ($bootstrapScript === '') {
+                        $bootstrapScript = 'vendor/autoload.php';
+                    }
+
+                    if ($testsDirectory === '') {
+                        $testsDirectory = 'tests';
+                    }
+
+                    if ($src === '') {
+                        $src = 'src';
+                    }
+
+                    $generator = new ConfigurationGenerator;
+
+                    \file_put_contents(
+                        'phpunit.xml',
+                        $generator->generateDefaultConfiguration(
+                            Version::series(),
+                            $bootstrapScript,
+                            $testsDirectory,
+                            $src
+                        )
+                    );
+
+                    print \PHP_EOL . 'Generated phpunit.xml in ' . \getcwd() . \PHP_EOL;
+
+                    exit(TestRunner::SUCCESS_EXIT);
+
+                    break;
+
+                case '--group':
+                    $this->arguments['groups'] = \explode(',', $option[1]);
+
+                    break;
+
+                case '--exclude-group':
+                    $this->arguments['excludeGroups'] = \explode(
+                        ',',
+                        $option[1]
+                    );
+
+                    break;
+
+                case '--test-suffix':
+                    $this->arguments['testSuffixes'] = \explode(
+                        ',',
+                        $option[1]
+                    );
+
+                    break;
+
+                case '--include-path':
+                    $includePath = $option[1];
+
+                    break;
+
+                case '--list-groups':
+                    $this->arguments['listGroups'] = true;
+
+                    break;
+
+                case '--list-suites':
+                    $this->arguments['listSuites'] = true;
+
+                    break;
+
+                case '--list-tests':
+                    $this->arguments['listTests'] = true;
+
+                    break;
+
+                case '--list-tests-xml':
+                    $this->arguments['listTestsXml'] = $option[1];
+
+                    break;
+
+                case '--printer':
+                    $this->arguments['printer'] = $option[1];
+
+                    break;
+
+                case '--loader':
+                    $this->arguments['loader'] = $option[1];
+
+                    break;
+
+                case '--log-junit':
+                    $this->arguments['junitLogfile'] = $option[1];
+
+                    break;
+
+                case '--log-teamcity':
+                    $this->arguments['teamcityLogfile'] = $option[1];
+
+                    break;
+
+                case '--order-by':
+                    $this->handleOrderByOption($option[1]);
+
+                    break;
+
+                case '--process-isolation':
+                    $this->arguments['processIsolation'] = true;
+
+                    break;
+
+                case '--repeat':
+                    $this->arguments['repeat'] = (int) $option[1];
+
+                    break;
+
+                case '--stderr':
+                    $this->arguments['stderr'] = true;
+
+                    break;
+
+                case '--stop-on-defect':
+                    $this->arguments['stopOnDefect'] = true;
+
+                    break;
+
+                case '--stop-on-error':
+                    $this->arguments['stopOnError'] = true;
+
+                    break;
+
+                case '--stop-on-failure':
+                    $this->arguments['stopOnFailure'] = true;
+
+                    break;
+
+                case '--stop-on-warning':
+                    $this->arguments['stopOnWarning'] = true;
+
+                    break;
+
+                case '--stop-on-incomplete':
+                    $this->arguments['stopOnIncomplete'] = true;
+
+                    break;
+
+                case '--stop-on-risky':
+                    $this->arguments['stopOnRisky'] = true;
+
+                    break;
+
+                case '--stop-on-skipped':
+                    $this->arguments['stopOnSkipped'] = true;
+
+                    break;
+
+                case '--fail-on-warning':
+                    $this->arguments['failOnWarning'] = true;
+
+                    break;
+
+                case '--fail-on-risky':
+                    $this->arguments['failOnRisky'] = true;
+
+                    break;
+
+                case '--teamcity':
+                    $this->arguments['printer'] = TeamCity::class;
+
+                    break;
+
+                case '--testdox':
+                    $this->arguments['printer'] = CliTestDoxPrinter::class;
+
+                    break;
+
+                case '--testdox-group':
+                    $this->arguments['testdoxGroups'] = \explode(
+                        ',',
+                        $option[1]
+                    );
+
+                    break;
+
+                case '--testdox-exclude-group':
+                    $this->arguments['testdoxExcludeGroups'] = \explode(
+                        ',',
+                        $option[1]
+                    );
+
+                    break;
+
+                case '--testdox-html':
+                    $this->arguments['testdoxHTMLFile'] = $option[1];
+
+                    break;
+
+                case '--testdox-text':
+                    $this->arguments['testdoxTextFile'] = $option[1];
+
+                    break;
+
+                case '--testdox-xml':
+                    $this->arguments['testdoxXMLFile'] = $option[1];
+
+                    break;
+
+                case '--no-configuration':
+                    $this->arguments['useDefaultConfiguration'] = false;
+
+                    break;
+
+                case '--no-extensions':
+                    $this->arguments['noExtensions'] = true;
+
+                    break;
+
+                case '--no-coverage':
+                    $this->arguments['noCoverage'] = true;
+
+                    break;
+
+                case '--no-logging':
+                    $this->arguments['noLogging'] = true;
+
+                    break;
+
+                case '--no-interaction':
+                    $this->arguments['noInteraction'] = true;
+
+                    break;
+
+                case '--globals-backup':
+                    $this->arguments['backupGlobals'] = true;
+
+                    break;
+
+                case '--static-backup':
+                    $this->arguments['backupStaticAttributes'] = true;
+
+                    break;
+
+                case 'v':
+                case '--verbose':
+                    $this->arguments['verbose'] = true;
+
+                    break;
+
+                case '--atleast-version':
+                    if (\version_compare(Version::id(), $option[1], '>=')) {
+                        exit(TestRunner::SUCCESS_EXIT);
+                    }
+
+                    exit(TestRunner::FAILURE_EXIT);
+
+                    break;
+
+                case '--version':
+                    $this->printVersionString();
+                    exit(TestRunner::SUCCESS_EXIT);
+
+                    break;
+
+                case '--dont-report-useless-tests':
+                    $this->arguments['reportUselessTests'] = false;
+
+                    break;
+
+                case '--strict-coverage':
+                    $this->arguments['strictCoverage'] = true;
+
+                    break;
+
+                case '--disable-coverage-ignore':
+                    $this->arguments['disableCodeCoverageIgnore'] = true;
+
+                    break;
+
+                case '--strict-global-state':
+                    $this->arguments['beStrictAboutChangesToGlobalState'] = true;
+
+                    break;
+
+                case '--disallow-test-output':
+                    $this->arguments['disallowTestOutput'] = true;
+
+                    break;
+
+                case '--disallow-resource-usage':
+                    $this->arguments['beStrictAboutResourceUsageDuringSmallTests'] = true;
+
+                    break;
+
+                case '--default-time-limit':
+                    $this->arguments['defaultTimeLimit'] = (int) $option[1];
+
+                    break;
+
+                case '--enforce-time-limit':
+                    $this->arguments['enforceTimeLimit'] = true;
+
+                    break;
+
+                case '--disallow-todo-tests':
+                    $this->arguments['disallowTodoAnnotatedTests'] = true;
+
+                    break;
+
+                case '--reverse-list':
+                    $this->arguments['reverseList'] = true;
+
+                    break;
+
+                case '--check-version':
+                    $this->handleVersionCheck();
+
+                    break;
+
+                case '--whitelist':
+                    $this->arguments['whitelist'] = $option[1];
+
+                    break;
+
+                case '--random-order':
+                    $this->handleOrderByOption('random');
+
+                    break;
+
+                case '--random-order-seed':
+                    $this->arguments['randomOrderSeed'] = (int) $option[1];
+
+                    break;
+
+                case '--resolve-dependencies':
+                    $this->handleOrderByOption('depends');
+
+                    break;
+
+                case '--ignore-dependencies':
+                    $this->handleOrderByOption('no-depends');
+
+                    break;
+
+                case '--reverse-order':
+                    $this->handleOrderByOption('reverse');
+
+                    break;
+
+                case '--dump-xdebug-filter':
+                    $this->arguments['xdebugFilterFile'] = $option[1];
+
+                    break;
+
+                default:
+                    $optionName = \str_replace('--', '', $option[0]);
+
+                    $handler = null;
+
+                    if (isset($this->longOptions[$optionName])) {
+                        $handler = $this->longOptions[$optionName];
+                    } elseif (isset($this->longOptions[$optionName . '='])) {
+                        $handler = $this->longOptions[$optionName . '='];
+                    }
+
+                    if (isset($handler) && \is_callable([$this, $handler])) {
+                        $this->$handler($option[1]);
+                    }
+            }
+        }
+
+        $this->handleCustomTestSuite();
+
+        if (!isset($this->arguments['testSuffixes'])) {
+            $this->arguments['testSuffixes'] = ['Test.php', '.phpt'];
+        }
+
+        if (isset($this->options[1][0]) &&
+            \substr($this->options[1][0], -5, 5) !== '.phpt' &&
+            \substr($this->options[1][0], -4, 4) !== '.php' &&
+            \substr($this->options[1][0], -1, 1) !== '/' &&
+            !\is_dir($this->options[1][0])) {
+            $this->arguments['warnings'][] = 'Invocation with class name is deprecated';
+        }
+
+        if (!isset($this->arguments['test'])) {
+            if (isset($this->options[1][0])) {
+                $this->arguments['test'] = $this->options[1][0];
+            }
+
+            if (isset($this->options[1][1])) {
+                $testFile = \realpath($this->options[1][1]);
+
+                if ($testFile === false) {
+                    $this->exitWithErrorMessage(
+                        \sprintf(
+                            'Cannot open file "%s".',
+                            $this->options[1][1]
+                        )
+                    );
+                }
+                $this->arguments['testFile'] = $testFile;
+            } else {
+                $this->arguments['testFile'] = '';
+            }
+
+            if (isset($this->arguments['test']) &&
+                \is_file($this->arguments['test']) &&
+                \strrpos($this->arguments['test'], '.') !== false &&
+                \substr($this->arguments['test'], -5, 5) !== '.phpt') {
+                $this->arguments['testFile'] = \realpath($this->arguments['test']);
+                $this->arguments['test']     = \substr($this->arguments['test'], 0, \strrpos($this->arguments['test'], '.'));
+            }
+
+            if (isset($this->arguments['test']) &&
+                \is_string($this->arguments['test']) &&
+                \substr($this->arguments['test'], -5, 5) === '.phpt') {
+                $suite = new TestSuite;
+                $suite->addTestFile($this->arguments['test']);
+                $this->arguments['test'] = $suite;
+            }
+        }
+
+        if (isset($includePath)) {
+            \ini_set(
+                'include_path',
+                $includePath . \PATH_SEPARATOR . \ini_get('include_path')
+            );
+        }
+
+        if ($this->arguments['loader'] !== null) {
+            $this->arguments['loader'] = $this->handleLoader($this->arguments['loader']);
+        }
+
+        if (isset($this->arguments['configuration']) &&
+            \is_dir($this->arguments['configuration'])) {
+            $configurationFile = $this->arguments['configuration'] . '/phpunit.xml';
+
+            if (\file_exists($configurationFile)) {
+                $this->arguments['configuration'] = \realpath(
+                    $configurationFile
+                );
+            } elseif (\file_exists($configurationFile . '.dist')) {
+                $this->arguments['configuration'] = \realpath(
+                    $configurationFile . '.dist'
+                );
+            }
+        } elseif (!isset($this->arguments['configuration']) &&
+            $this->arguments['useDefaultConfiguration']) {
+            if (\file_exists('phpunit.xml')) {
+                $this->arguments['configuration'] = \realpath('phpunit.xml');
+            } elseif (\file_exists('phpunit.xml.dist')) {
+                $this->arguments['configuration'] = \realpath(
+                    'phpunit.xml.dist'
+                );
+            }
+        }
+
+        if (isset($this->arguments['configuration'])) {
+            try {
+                $configuration = Configuration::getInstance(
+                    $this->arguments['configuration']
+                );
+            } catch (Throwable $t) {
+                print $t->getMessage() . \PHP_EOL;
+                exit(TestRunner::FAILURE_EXIT);
+            }
+
+            $phpunitConfiguration = $configuration->getPHPUnitConfiguration();
+
+            $configuration->handlePHPConfiguration();
+
+            /*
+             * Issue #1216
+             */
+            if (isset($this->arguments['bootstrap'])) {
+                $this->handleBootstrap($this->arguments['bootstrap']);
+            } elseif (isset($phpunitConfiguration['bootstrap'])) {
+                $this->handleBootstrap($phpunitConfiguration['bootstrap']);
+            }
+
+            /*
+             * Issue #657
+             */
+            if (isset($phpunitConfiguration['stderr']) && !isset($this->arguments['stderr'])) {
+                $this->arguments['stderr'] = $phpunitConfiguration['stderr'];
+            }
+
+            if (isset($phpunitConfiguration['extensionsDirectory']) && !isset($this->arguments['noExtensions']) && \extension_loaded('phar')) {
+                $this->handleExtensions($phpunitConfiguration['extensionsDirectory']);
+            }
+
+            if (isset($phpunitConfiguration['columns']) && !isset($this->arguments['columns'])) {
+                $this->arguments['columns'] = $phpunitConfiguration['columns'];
+            }
+
+            if (!isset($this->arguments['printer']) && isset($phpunitConfiguration['printerClass'])) {
+                $file = $phpunitConfiguration['printerFile'] ?? '';
+
+                $this->arguments['printer'] = $this->handlePrinter(
+                    $phpunitConfiguration['printerClass'],
+                    $file
+                );
+            }
+
+            if (isset($phpunitConfiguration['testSuiteLoaderClass'])) {
+                $file = $phpunitConfiguration['testSuiteLoaderFile'] ?? '';
+
+                $this->arguments['loader'] = $this->handleLoader(
+                    $phpunitConfiguration['testSuiteLoaderClass'],
+                    $file
+                );
+            }
+
+            if (!isset($this->arguments['testsuite']) && isset($phpunitConfiguration['defaultTestSuite'])) {
+                $this->arguments['testsuite'] = $phpunitConfiguration['defaultTestSuite'];
+            }
+
+            if (!isset($this->arguments['test'])) {
+                $testSuite = $configuration->getTestSuiteConfiguration($this->arguments['testsuite'] ?? '');
+
+                if ($testSuite !== null) {
+                    $this->arguments['test'] = $testSuite;
+                }
+            }
+        } elseif (isset($this->arguments['bootstrap'])) {
+            $this->handleBootstrap($this->arguments['bootstrap']);
+        }
+
+        if (isset($this->arguments['printer']) &&
+            \is_string($this->arguments['printer'])) {
+            $this->arguments['printer'] = $this->handlePrinter($this->arguments['printer']);
+        }
+
+        if (!isset($this->arguments['test'])) {
+            $this->showHelp();
+            exit(TestRunner::EXCEPTION_EXIT);
+        }
+    }
+
+    /**
+     * Handles the loading of the PHPUnit\Runner\TestSuiteLoader implementation.
+     */
+    protected function handleLoader(string $loaderClass, string $loaderFile = ''): ?TestSuiteLoader
+    {
+        if (!\class_exists($loaderClass, false)) {
+            if ($loaderFile == '') {
+                $loaderFile = Filesystem::classNameToFilename(
+                    $loaderClass
+                );
+            }
+
+            $loaderFile = \stream_resolve_include_path($loaderFile);
+
+            if ($loaderFile) {
+                require $loaderFile;
+            }
+        }
+
+        if (\class_exists($loaderClass, false)) {
+            try {
+                $class = new \ReflectionClass($loaderClass);
+                // @codeCoverageIgnoreStart
+            } catch (\ReflectionException $e) {
+                throw new Exception(
+                    $e->getMessage(),
+                    (int) $e->getCode(),
+                    $e
+                );
+            }
+            // @codeCoverageIgnoreEnd
+
+            if ($class->implementsInterface(TestSuiteLoader::class) && $class->isInstantiable()) {
+                $object = $class->newInstance();
+
+                \assert($object instanceof TestSuiteLoader);
+
+                return $object;
+            }
+        }
+
+        if ($loaderClass == StandardTestSuiteLoader::class) {
+            return null;
+        }
+
+        $this->exitWithErrorMessage(
+            \sprintf(
+                'Could not use "%s" as loader.',
+                $loaderClass
+            )
+        );
+
+        return null;
+    }
+
+    /**
+     * Handles the loading of the PHPUnit\Util\Printer implementation.
+     *
+     * @return null|Printer|string
+     */
+    protected function handlePrinter(string $printerClass, string $printerFile = '')
+    {
+        if (!\class_exists($printerClass, false)) {
+            if ($printerFile == '') {
+                $printerFile = Filesystem::classNameToFilename(
+                    $printerClass
+                );
+            }
+
+            $printerFile = \stream_resolve_include_path($printerFile);
+
+            if ($printerFile) {
+                require $printerFile;
+            }
+        }
+
+        if (!\class_exists($printerClass)) {
+            $this->exitWithErrorMessage(
+                \sprintf(
+                    'Could not use "%s" as printer: class does not exist',
+                    $printerClass
+                )
+            );
+        }
+
+        try {
+            $class = new \ReflectionClass($printerClass);
+            // @codeCoverageIgnoreStart
+        } catch (\ReflectionException $e) {
+            throw new Exception(
+                $e->getMessage(),
+                (int) $e->getCode(),
+                $e
+            );
+            // @codeCoverageIgnoreEnd
+        }
+
+        if (!$class->implementsInterface(TestListener::class)) {
+            $this->exitWithErrorMessage(
+                \sprintf(
+                    'Could not use "%s" as printer: class does not implement %s',
+                    $printerClass,
+                    TestListener::class
+                )
+            );
+        }
+
+        if (!$class->isSubclassOf(Printer::class)) {
+            $this->exitWithErrorMessage(
+                \sprintf(
+                    'Could not use "%s" as printer: class does not extend %s',
+                    $printerClass,
+                    Printer::class
+                )
+            );
+        }
+
+        if (!$class->isInstantiable()) {
+            $this->exitWithErrorMessage(
+                \sprintf(
+                    'Could not use "%s" as printer: class cannot be instantiated',
+                    $printerClass
+                )
+            );
+        }
+
+        if ($class->isSubclassOf(ResultPrinter::class)) {
+            return $printerClass;
+        }
+
+        $outputStream = isset($this->arguments['stderr']) ? 'php://stderr' : null;
+
+        return $class->newInstance($outputStream);
+    }
+
+    /**
+     * Loads a bootstrap file.
+     */
+    protected function handleBootstrap(string $filename): void
+    {
+        try {
+            FileLoader::checkAndLoad($filename);
+        } catch (Exception $e) {
+            $this->exitWithErrorMessage($e->getMessage());
+        }
+    }
+
+    protected function handleVersionCheck(): void
+    {
+        $this->printVersionString();
+
+        $latestVersion = \file_get_contents('https://phar.phpunit.de/latest-version-of/phpunit');
+        $isOutdated    = \version_compare($latestVersion, Version::id(), '>');
+
+        if ($isOutdated) {
+            \printf(
+                'You are not using the latest version of PHPUnit.' . \PHP_EOL .
+                'The latest version is PHPUnit %s.' . \PHP_EOL,
+                $latestVersion
+            );
+        } else {
+            print 'You are using the latest version of PHPUnit.' . \PHP_EOL;
+        }
+
+        exit(TestRunner::SUCCESS_EXIT);
+    }
+
+    /**
+     * Show the help message.
+     */
     protected function showHelp(): void
     {
-        parent::showHelp();
-
+        $this->printVersionString();
+        (new Help)->writeToConsole();
         echo <<<EOT
 
 Slices Options:
@@ -51,8 +1150,210 @@ Slices Options:
 EOT;
     }
 
-    protected function createRunner(): \PHPUnit\TextUI\TestRunner
+    /**
+     * Custom callback for test suite discovery.
+     */
+    protected function handleCustomTestSuite(): void
     {
-        return new TestRunner($this->arguments['loader']);
+    }
+
+    private function printVersionString(): void
+    {
+        if ($this->versionStringPrinted) {
+            return;
+        }
+
+        print Version::getVersionString() . \PHP_EOL . \PHP_EOL;
+
+        $this->versionStringPrinted = true;
+    }
+
+    private function exitWithErrorMessage(string $message): void
+    {
+        $this->printVersionString();
+
+        print $message . \PHP_EOL;
+
+        exit(TestRunner::FAILURE_EXIT);
+    }
+
+    private function handleExtensions(string $directory): void
+    {
+        foreach ((new FileIteratorFacade)->getFilesAsArray($directory, '.phar') as $file) {
+            if (!\file_exists('phar://' . $file . '/manifest.xml')) {
+                $this->arguments['notLoadedExtensions'][] = $file . ' is not an extension for PHPUnit';
+
+                continue;
+            }
+
+            try {
+                $applicationName = new ApplicationName('phpunit/phpunit');
+                $version         = new PharIoVersion(Version::series());
+                $manifest        = ManifestLoader::fromFile('phar://' . $file . '/manifest.xml');
+
+                if (!$manifest->isExtensionFor($applicationName)) {
+                    $this->arguments['notLoadedExtensions'][] = $file . ' is not an extension for PHPUnit';
+
+                    continue;
+                }
+
+                if (!$manifest->isExtensionFor($applicationName, $version)) {
+                    $this->arguments['notLoadedExtensions'][] = $file . ' is not compatible with this version of PHPUnit';
+
+                    continue;
+                }
+            } catch (ManifestException $e) {
+                $this->arguments['notLoadedExtensions'][] = $file . ': ' . $e->getMessage();
+
+                continue;
+            }
+
+            require $file;
+
+            $this->arguments['loadedExtensions'][] = $manifest->getName() . ' ' . $manifest->getVersion()->getVersionString();
+        }
+    }
+
+    private function handleListGroups(TestSuite $suite, bool $exit): int
+    {
+        $this->printVersionString();
+
+        print 'Available test group(s):' . \PHP_EOL;
+
+        $groups = $suite->getGroups();
+        \sort($groups);
+
+        foreach ($groups as $group) {
+            \printf(
+                ' - %s' . \PHP_EOL,
+                $group
+            );
+        }
+
+        if ($exit) {
+            exit(TestRunner::SUCCESS_EXIT);
+        }
+
+        return TestRunner::SUCCESS_EXIT;
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\Exception
+     */
+    private function handleListSuites(bool $exit): int
+    {
+        $this->printVersionString();
+
+        print 'Available test suite(s):' . \PHP_EOL;
+
+        $configuration = Configuration::getInstance(
+            $this->arguments['configuration']
+        );
+
+        foreach ($configuration->getTestSuiteNames() as $suiteName) {
+            \printf(
+                ' - %s' . \PHP_EOL,
+                $suiteName
+            );
+        }
+
+        if ($exit) {
+            exit(TestRunner::SUCCESS_EXIT);
+        }
+
+        return TestRunner::SUCCESS_EXIT;
+    }
+
+    /**
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    private function handleListTests(TestSuite $suite, bool $exit): int
+    {
+        $this->printVersionString();
+
+        $renderer = new TextTestListRenderer;
+
+        print $renderer->render($suite);
+
+        if ($exit) {
+            exit(TestRunner::SUCCESS_EXIT);
+        }
+
+        return TestRunner::SUCCESS_EXIT;
+    }
+
+    /**
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    private function handleListTestsXml(TestSuite $suite, string $target, bool $exit): int
+    {
+        $this->printVersionString();
+
+        $renderer = new XmlTestListRenderer;
+
+        \file_put_contents($target, $renderer->render($suite));
+
+        \printf(
+            'Wrote list of tests that would have been run to %s' . \PHP_EOL,
+            $target
+        );
+
+        if ($exit) {
+            exit(TestRunner::SUCCESS_EXIT);
+        }
+
+        return TestRunner::SUCCESS_EXIT;
+    }
+
+    private function handleOrderByOption(string $value): void
+    {
+        foreach (\explode(',', $value) as $order) {
+            switch ($order) {
+                case 'default':
+                    $this->arguments['executionOrder']        = TestSuiteSorter::ORDER_DEFAULT;
+                    $this->arguments['executionOrderDefects'] = TestSuiteSorter::ORDER_DEFAULT;
+                    $this->arguments['resolveDependencies']   = true;
+
+                    break;
+
+                case 'defects':
+                    $this->arguments['executionOrderDefects'] = TestSuiteSorter::ORDER_DEFECTS_FIRST;
+
+                    break;
+
+                case 'depends':
+                    $this->arguments['resolveDependencies'] = true;
+
+                    break;
+
+                case 'duration':
+                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_DURATION;
+
+                    break;
+
+                case 'no-depends':
+                    $this->arguments['resolveDependencies'] = false;
+
+                    break;
+
+                case 'random':
+                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_RANDOMIZED;
+
+                    break;
+
+                case 'reverse':
+                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_REVERSED;
+
+                    break;
+
+                case 'size':
+                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_SIZE;
+
+                    break;
+
+                default:
+                    $this->exitWithErrorMessage("unrecognized --order-by option: $order");
+            }
+        }
     }
 }

--- a/src/TestRunner.php
+++ b/src/TestRunner.php
@@ -4,13 +4,118 @@ declare(strict_types=1);
 
 namespace Wizaplace\PHPUnit\Slicer;
 
+use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\TestSuite;
+use PHPUnit\Runner\AfterLastTestHook;
+use PHPUnit\Runner\BaseTestRunner;
+use PHPUnit\Runner\BeforeFirstTestHook;
+use PHPUnit\Runner\DefaultTestResultCache;
+use PHPUnit\Runner\Filter\ExcludeGroupFilterIterator;
+use PHPUnit\Runner\Filter\Factory;
+use PHPUnit\Runner\Filter\IncludeGroupFilterIterator;
+use PHPUnit\Runner\Filter\NameFilterIterator;
+use PHPUnit\Runner\Hook;
+use PHPUnit\Runner\NullTestResultCache;
+use PHPUnit\Runner\ResultCacheExtension;
+use PHPUnit\Runner\StandardTestSuiteLoader;
+use PHPUnit\Runner\TestHook;
+use PHPUnit\Runner\TestListenerAdapter;
+use PHPUnit\Runner\TestSuiteLoader;
+use PHPUnit\Runner\TestSuiteSorter;
+use PHPUnit\Runner\Version;
+use PHPUnit\TextUI\ResultPrinter;
+use PHPUnit\Util\Configuration;
+use PHPUnit\Util\Filesystem;
+use PHPUnit\Util\Log\JUnit;
+use PHPUnit\Util\Log\TeamCity;
+use PHPUnit\Util\Printer;
+use PHPUnit\Util\TestDox\CliTestDoxPrinter;
+use PHPUnit\Util\TestDox\HtmlResultPrinter;
+use PHPUnit\Util\TestDox\TextResultPrinter;
+use PHPUnit\Util\TestDox\XmlResultPrinter;
+use PHPUnit\Util\XdebugFilterScriptGenerator;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Exception as CodeCoverageException;
+use SebastianBergmann\CodeCoverage\Filter as CodeCoverageFilter;
+use SebastianBergmann\CodeCoverage\Report\Clover as CloverReport;
+use SebastianBergmann\CodeCoverage\Report\Crap4j as Crap4jReport;
+use SebastianBergmann\CodeCoverage\Report\Html\Facade as HtmlReport;
+use SebastianBergmann\CodeCoverage\Report\PHP as PhpReport;
+use SebastianBergmann\CodeCoverage\Report\Text as TextReport;
+use SebastianBergmann\CodeCoverage\Report\Xml\Facade as XmlReport;
+use SebastianBergmann\Comparator\Comparator;
+use SebastianBergmann\Environment\Runtime;
+use SebastianBergmann\Invoker\Invoker;
+use SebastianBergmann\Timer\Timer;
 
-class TestRunner extends \PHPUnit\TextUI\TestRunner
+/**
+ * Since PHPUnit made this class final, we have to copy-and-paste it all to change it.
+ *
+ * @see \PHPUnit\TextUI\TestRunner
+ */
+class TestRunner extends BaseTestRunner
 {
-    public function doRun(Test $suite, array $arguments = [], $exit = true): TestResult
+    public const SUCCESS_EXIT   = 0;
+
+    public const FAILURE_EXIT   = 1;
+
+    public const EXCEPTION_EXIT = 2;
+
+    /**
+     * @var bool
+     */
+    private static $versionStringPrinted = false;
+
+    /**
+     * @var CodeCoverageFilter
+     */
+    private $codeCoverageFilter;
+
+    /**
+     * @var TestSuiteLoader
+     */
+    private $loader;
+
+    /**
+     * @var Printer&TestListener
+     */
+    private $printer;
+
+    /**
+     * @var Runtime
+     */
+    private $runtime;
+
+    /**
+     * @var bool
+     */
+    private $messagePrinted = false;
+
+    /**
+     * @var Hook[]
+     */
+    private $extensions = [];
+
+    public function __construct(TestSuiteLoader $loader = null, CodeCoverageFilter $filter = null)
+    {
+        if ($filter === null) {
+            $filter = new CodeCoverageFilter;
+        }
+
+        $this->codeCoverageFilter = $filter;
+        $this->loader             = $loader;
+        $this->runtime            = new Runtime;
+    }
+
+    /**
+     * @throws \PHPUnit\Runner\Exception
+     * @throws Exception
+     */
+    public function doRun(Test $suite, array $arguments = [], bool $exit = true): TestResult
     {
         if (isset($arguments['totalSlices'], $arguments['currentSlice']) && $suite instanceof TestSuite) {
             $localArguments = $arguments;
@@ -19,6 +124,1239 @@ class TestRunner extends \PHPUnit\TextUI\TestRunner
             TestSuiteSlicer::slice($suite, $localArguments);
         }
 
-        return parent::doRun($suite, $arguments, $exit);
+        if (isset($arguments['configuration'])) {
+            $GLOBALS['__PHPUNIT_CONFIGURATION_FILE'] = $arguments['configuration'];
+        }
+
+        $this->handleConfiguration($arguments);
+
+        if (\is_int($arguments['columns']) && $arguments['columns'] < 16) {
+            $arguments['columns']   = 16;
+            $tooFewColumnsRequested = true;
+        }
+
+        if (isset($arguments['bootstrap'])) {
+            $GLOBALS['__PHPUNIT_BOOTSTRAP'] = $arguments['bootstrap'];
+        }
+
+        if ($suite instanceof TestCase || $suite instanceof TestSuite) {
+            if ($arguments['backupGlobals'] === true) {
+                $suite->setBackupGlobals(true);
+            }
+
+            if ($arguments['backupStaticAttributes'] === true) {
+                $suite->setBackupStaticAttributes(true);
+            }
+
+            if ($arguments['beStrictAboutChangesToGlobalState'] === true) {
+                $suite->setBeStrictAboutChangesToGlobalState(true);
+            }
+        }
+
+        if ($arguments['executionOrder'] === TestSuiteSorter::ORDER_RANDOMIZED) {
+            \mt_srand($arguments['randomOrderSeed']);
+        }
+
+        if ($arguments['cacheResult']) {
+            if (!isset($arguments['cacheResultFile'])) {
+                if (isset($arguments['configuration']) && $arguments['configuration'] instanceof Configuration) {
+                    $cacheLocation = $arguments['configuration']->getFilename();
+                } else {
+                    $cacheLocation = $_SERVER['PHP_SELF'];
+                }
+
+                $arguments['cacheResultFile'] = null;
+
+                $cacheResultFile = \realpath($cacheLocation);
+
+                if ($cacheResultFile !== false) {
+                    $arguments['cacheResultFile'] = \dirname($cacheResultFile);
+                }
+            }
+
+            $cache = new DefaultTestResultCache($arguments['cacheResultFile']);
+
+            $this->addExtension(new ResultCacheExtension($cache));
+        }
+
+        if ($arguments['executionOrder'] !== TestSuiteSorter::ORDER_DEFAULT || $arguments['executionOrderDefects'] !== TestSuiteSorter::ORDER_DEFAULT || $arguments['resolveDependencies']) {
+            $cache = $cache ?? new NullTestResultCache;
+
+            $cache->load();
+
+            $sorter = new TestSuiteSorter($cache);
+
+            $sorter->reorderTestsInSuite($suite, $arguments['executionOrder'], $arguments['resolveDependencies'], $arguments['executionOrderDefects']);
+            $originalExecutionOrder = $sorter->getOriginalExecutionOrder();
+
+            unset($sorter);
+        }
+
+        if (\is_int($arguments['repeat']) && $arguments['repeat'] > 0) {
+            $_suite = new TestSuite;
+
+            /* @noinspection PhpUnusedLocalVariableInspection */
+            foreach (\range(1, $arguments['repeat']) as $step) {
+                $_suite->addTest($suite);
+            }
+
+            $suite = $_suite;
+
+            unset($_suite);
+        }
+
+        $result = $this->createTestResult();
+
+        $listener       = new TestListenerAdapter;
+        $listenerNeeded = false;
+
+        foreach ($this->extensions as $extension) {
+            if ($extension instanceof TestHook) {
+                $listener->add($extension);
+
+                $listenerNeeded = true;
+            }
+        }
+
+        if ($listenerNeeded) {
+            $result->addListener($listener);
+        }
+
+        unset($listener, $listenerNeeded);
+
+        if (!$arguments['convertDeprecationsToExceptions']) {
+            $result->convertDeprecationsToExceptions(false);
+        }
+
+        if (!$arguments['convertErrorsToExceptions']) {
+            $result->convertErrorsToExceptions(false);
+        }
+
+        if (!$arguments['convertNoticesToExceptions']) {
+            $result->convertNoticesToExceptions(false);
+        }
+
+        if (!$arguments['convertWarningsToExceptions']) {
+            $result->convertWarningsToExceptions(false);
+        }
+
+        if ($arguments['stopOnError']) {
+            $result->stopOnError(true);
+        }
+
+        if ($arguments['stopOnFailure']) {
+            $result->stopOnFailure(true);
+        }
+
+        if ($arguments['stopOnWarning']) {
+            $result->stopOnWarning(true);
+        }
+
+        if ($arguments['stopOnIncomplete']) {
+            $result->stopOnIncomplete(true);
+        }
+
+        if ($arguments['stopOnRisky']) {
+            $result->stopOnRisky(true);
+        }
+
+        if ($arguments['stopOnSkipped']) {
+            $result->stopOnSkipped(true);
+        }
+
+        if ($arguments['stopOnDefect']) {
+            $result->stopOnDefect(true);
+        }
+
+        if ($arguments['registerMockObjectsFromTestArgumentsRecursively']) {
+            $result->setRegisterMockObjectsFromTestArgumentsRecursively(true);
+        }
+
+        if ($this->printer === null) {
+            if (isset($arguments['printer'])) {
+                if ($arguments['printer'] instanceof Printer && $arguments['printer'] instanceof TestListener) {
+                    $this->printer = $arguments['printer'];
+                } elseif (\is_string($arguments['printer']) && \class_exists($arguments['printer'], false)) {
+                    try {
+                        new \ReflectionClass($arguments['printer']);
+                        // @codeCoverageIgnoreStart
+                    } catch (\ReflectionException $e) {
+                        throw new Exception(
+                            $e->getMessage(),
+                            (int) $e->getCode(),
+                            $e
+                        );
+                    }
+                    // @codeCoverageIgnoreEnd
+
+                    if (\is_subclass_of($arguments['printer'], ResultPrinter::class)) {
+                        $this->printer = $this->createPrinter($arguments['printer'], $arguments);
+                    }
+                }
+            } else {
+                $this->printer = $this->createPrinter(ResultPrinter::class, $arguments);
+            }
+        }
+
+        if (isset($originalExecutionOrder) && $this->printer instanceof CliTestDoxPrinter) {
+            \assert($this->printer instanceof CliTestDoxPrinter);
+
+            $this->printer->setOriginalExecutionOrder($originalExecutionOrder);
+            $this->printer->setShowProgressAnimation(!$arguments['noInteraction']);
+        }
+
+        $this->printer->write(
+            Version::getVersionString() . "\n"
+        );
+
+        self::$versionStringPrinted = true;
+
+        if ($arguments['verbose']) {
+            $this->writeMessage('Runtime', $this->runtime->getNameWithVersionAndCodeCoverageDriver());
+
+            if (isset($arguments['configuration'])) {
+                $this->writeMessage(
+                    'Configuration',
+                    $arguments['configuration']->getFilename()
+                );
+            }
+
+            foreach ($arguments['loadedExtensions'] as $extension) {
+                $this->writeMessage(
+                    'Extension',
+                    $extension
+                );
+            }
+
+            foreach ($arguments['notLoadedExtensions'] as $extension) {
+                $this->writeMessage(
+                    'Extension',
+                    $extension
+                );
+            }
+        }
+
+        foreach ($arguments['warnings'] as $warning) {
+            $this->writeMessage('Warning', $warning);
+        }
+
+        if ($arguments['executionOrder'] === TestSuiteSorter::ORDER_RANDOMIZED) {
+            $this->writeMessage(
+                'Random seed',
+                (string) $arguments['randomOrderSeed']
+            );
+        }
+
+        if (isset($tooFewColumnsRequested)) {
+            $this->writeMessage('Error', 'Less than 16 columns requested, number of columns set to 16');
+        }
+
+        if ($this->runtime->discardsComments()) {
+            $this->writeMessage('Warning', 'opcache.save_comments=0 set; annotations will not work');
+        }
+
+        if (isset($arguments['configuration']) && $arguments['configuration']->hasValidationErrors()) {
+            $this->write(
+                "\n  Warning - The configuration file did not pass validation!\n  The following problems have been detected:\n"
+            );
+
+            foreach ($arguments['configuration']->getValidationErrors() as $line => $errors) {
+                $this->write(\sprintf("\n  Line %d:\n", $line));
+
+                foreach ($errors as $msg) {
+                    $this->write(\sprintf("  - %s\n", $msg));
+                }
+            }
+
+            $this->write("\n  Test results may not be as expected.\n\n");
+        }
+
+        if (isset($arguments['conflictBetweenPrinterClassAndTestdox'])) {
+            $this->writeMessage('Warning', 'Directives printerClass and testdox are mutually exclusive');
+        }
+
+        foreach ($arguments['listeners'] as $listener) {
+            $result->addListener($listener);
+        }
+
+        $result->addListener($this->printer);
+
+        $codeCoverageReports = 0;
+
+        if (!isset($arguments['noLogging'])) {
+            if (isset($arguments['testdoxHTMLFile'])) {
+                $result->addListener(
+                    new HtmlResultPrinter(
+                        $arguments['testdoxHTMLFile'],
+                        $arguments['testdoxGroups'],
+                        $arguments['testdoxExcludeGroups']
+                    )
+                );
+            }
+
+            if (isset($arguments['testdoxTextFile'])) {
+                $result->addListener(
+                    new TextResultPrinter(
+                        $arguments['testdoxTextFile'],
+                        $arguments['testdoxGroups'],
+                        $arguments['testdoxExcludeGroups']
+                    )
+                );
+            }
+
+            if (isset($arguments['testdoxXMLFile'])) {
+                $result->addListener(
+                    new XmlResultPrinter(
+                        $arguments['testdoxXMLFile']
+                    )
+                );
+            }
+
+            if (isset($arguments['teamcityLogfile'])) {
+                $result->addListener(
+                    new TeamCity($arguments['teamcityLogfile'])
+                );
+            }
+
+            if (isset($arguments['junitLogfile'])) {
+                $result->addListener(
+                    new JUnit(
+                        $arguments['junitLogfile'],
+                        $arguments['reportUselessTests']
+                    )
+                );
+            }
+
+            if (isset($arguments['coverageClover'])) {
+                $codeCoverageReports++;
+            }
+
+            if (isset($arguments['coverageCrap4J'])) {
+                $codeCoverageReports++;
+            }
+
+            if (isset($arguments['coverageHtml'])) {
+                $codeCoverageReports++;
+            }
+
+            if (isset($arguments['coveragePHP'])) {
+                $codeCoverageReports++;
+            }
+
+            if (isset($arguments['coverageText'])) {
+                $codeCoverageReports++;
+            }
+
+            if (isset($arguments['coverageXml'])) {
+                $codeCoverageReports++;
+            }
+        }
+
+        if (isset($arguments['noCoverage'])) {
+            $codeCoverageReports = 0;
+        }
+
+        if ($codeCoverageReports > 0 && !$this->runtime->canCollectCodeCoverage()) {
+            $this->writeMessage('Error', 'No code coverage driver is available');
+
+            $codeCoverageReports = 0;
+        }
+
+        if ($codeCoverageReports > 0 || isset($arguments['xdebugFilterFile'])) {
+            $whitelistFromConfigurationFile = false;
+            $whitelistFromOption            = false;
+
+            if (isset($arguments['whitelist'])) {
+                $this->codeCoverageFilter->addDirectoryToWhitelist($arguments['whitelist']);
+
+                $whitelistFromOption = true;
+            }
+
+            if (isset($arguments['configuration'])) {
+                $filterConfiguration = $arguments['configuration']->getFilterConfiguration();
+
+                if (!empty($filterConfiguration['whitelist'])) {
+                    $whitelistFromConfigurationFile = true;
+                }
+
+                if (!empty($filterConfiguration['whitelist'])) {
+                    foreach ($filterConfiguration['whitelist']['include']['directory'] as $dir) {
+                        $this->codeCoverageFilter->addDirectoryToWhitelist(
+                            $dir['path'],
+                            $dir['suffix'],
+                            $dir['prefix']
+                        );
+                    }
+
+                    foreach ($filterConfiguration['whitelist']['include']['file'] as $file) {
+                        $this->codeCoverageFilter->addFileToWhitelist($file);
+                    }
+
+                    foreach ($filterConfiguration['whitelist']['exclude']['directory'] as $dir) {
+                        $this->codeCoverageFilter->removeDirectoryFromWhitelist(
+                            $dir['path'],
+                            $dir['suffix'],
+                            $dir['prefix']
+                        );
+                    }
+
+                    foreach ($filterConfiguration['whitelist']['exclude']['file'] as $file) {
+                        $this->codeCoverageFilter->removeFileFromWhitelist($file);
+                    }
+                }
+            }
+        }
+
+        if ($codeCoverageReports > 0) {
+            $codeCoverage = new CodeCoverage(
+                null,
+                $this->codeCoverageFilter
+            );
+
+            $codeCoverage->setUnintentionallyCoveredSubclassesWhitelist(
+                [Comparator::class]
+            );
+
+            $codeCoverage->setCheckForUnintentionallyCoveredCode(
+                $arguments['strictCoverage']
+            );
+
+            $codeCoverage->setCheckForMissingCoversAnnotation(
+                $arguments['strictCoverage']
+            );
+
+            if (isset($arguments['forceCoversAnnotation'])) {
+                $codeCoverage->setForceCoversAnnotation(
+                    $arguments['forceCoversAnnotation']
+                );
+            }
+
+            if (isset($arguments['ignoreDeprecatedCodeUnitsFromCodeCoverage'])) {
+                $codeCoverage->setIgnoreDeprecatedCode(
+                    $arguments['ignoreDeprecatedCodeUnitsFromCodeCoverage']
+                );
+            }
+
+            if (isset($arguments['disableCodeCoverageIgnore'])) {
+                $codeCoverage->setDisableIgnoredLines(true);
+            }
+
+            if (!empty($filterConfiguration['whitelist'])) {
+                $codeCoverage->setAddUncoveredFilesFromWhitelist(
+                    $filterConfiguration['whitelist']['addUncoveredFilesFromWhitelist']
+                );
+
+                $codeCoverage->setProcessUncoveredFilesFromWhitelist(
+                    $filterConfiguration['whitelist']['processUncoveredFilesFromWhitelist']
+                );
+            }
+
+            if (!$this->codeCoverageFilter->hasWhitelist()) {
+                if (!$whitelistFromConfigurationFile && !$whitelistFromOption) {
+                    $this->writeMessage('Error', 'No whitelist is configured, no code coverage will be generated.');
+                } else {
+                    $this->writeMessage('Error', 'Incorrect whitelist config, no code coverage will be generated.');
+                }
+
+                $codeCoverageReports = 0;
+
+                unset($codeCoverage);
+            }
+        }
+
+        if (isset($arguments['xdebugFilterFile'], $filterConfiguration)) {
+            $this->write("\n");
+
+            $script = (new XdebugFilterScriptGenerator)->generate($filterConfiguration['whitelist']);
+
+            if ($arguments['xdebugFilterFile'] !== 'php://stdout' && $arguments['xdebugFilterFile'] !== 'php://stderr' && !Filesystem::createDirectory(\dirname($arguments['xdebugFilterFile']))) {
+                $this->write(\sprintf('Cannot write Xdebug filter script to %s ' . \PHP_EOL, $arguments['xdebugFilterFile']));
+
+                exit(self::EXCEPTION_EXIT);
+            }
+
+            \file_put_contents($arguments['xdebugFilterFile'], $script);
+
+            $this->write(\sprintf('Wrote Xdebug filter script to %s ' . \PHP_EOL, $arguments['xdebugFilterFile']));
+
+            exit(self::SUCCESS_EXIT);
+        }
+
+        $this->printer->write("\n");
+
+        if (isset($codeCoverage)) {
+            $result->setCodeCoverage($codeCoverage);
+
+            if ($codeCoverageReports > 1 && isset($arguments['cacheTokens'])) {
+                $codeCoverage->setCacheTokens($arguments['cacheTokens']);
+            }
+        }
+
+        $result->beStrictAboutTestsThatDoNotTestAnything($arguments['reportUselessTests']);
+        $result->beStrictAboutOutputDuringTests($arguments['disallowTestOutput']);
+        $result->beStrictAboutTodoAnnotatedTests($arguments['disallowTodoAnnotatedTests']);
+        $result->beStrictAboutResourceUsageDuringSmallTests($arguments['beStrictAboutResourceUsageDuringSmallTests']);
+
+        if ($arguments['enforceTimeLimit'] === true) {
+            if (!\class_exists(Invoker::class)) {
+                $this->writeMessage('Error', 'Package phpunit/php-invoker is required for enforcing time limits');
+            }
+
+            if (!\extension_loaded('pcntl') || \strpos(\ini_get('disable_functions'), 'pcntl') !== false) {
+                $this->writeMessage('Error', 'PHP extension pcntl is required for enforcing time limits');
+            }
+        }
+        $result->enforceTimeLimit($arguments['enforceTimeLimit']);
+        $result->setDefaultTimeLimit($arguments['defaultTimeLimit']);
+        $result->setTimeoutForSmallTests($arguments['timeoutForSmallTests']);
+        $result->setTimeoutForMediumTests($arguments['timeoutForMediumTests']);
+        $result->setTimeoutForLargeTests($arguments['timeoutForLargeTests']);
+
+        if ($suite instanceof TestSuite) {
+            $this->processSuiteFilters($suite, $arguments);
+            $suite->setRunTestInSeparateProcess($arguments['processIsolation']);
+        }
+
+        foreach ($this->extensions as $extension) {
+            if ($extension instanceof BeforeFirstTestHook) {
+                $extension->executeBeforeFirstTest();
+            }
+        }
+
+        $suite->run($result);
+
+        foreach ($this->extensions as $extension) {
+            if ($extension instanceof AfterLastTestHook) {
+                $extension->executeAfterLastTest();
+            }
+        }
+
+        $result->flushListeners();
+
+        if ($this->printer instanceof ResultPrinter) {
+            $this->printer->printResult($result);
+        }
+
+        if (isset($codeCoverage)) {
+            if (isset($arguments['coverageClover'])) {
+                $this->codeCoverageGenerationStart('Clover XML');
+
+                try {
+                    $writer = new CloverReport;
+                    $writer->process($codeCoverage, $arguments['coverageClover']);
+
+                    $this->codeCoverageGenerationSucceeded();
+
+                    unset($writer);
+                } catch (CodeCoverageException $e) {
+                    $this->codeCoverageGenerationFailed($e);
+                }
+            }
+
+            if (isset($arguments['coverageCrap4J'])) {
+                $this->codeCoverageGenerationStart('Crap4J XML');
+
+                try {
+                    $writer = new Crap4jReport($arguments['crap4jThreshold']);
+                    $writer->process($codeCoverage, $arguments['coverageCrap4J']);
+
+                    $this->codeCoverageGenerationSucceeded();
+
+                    unset($writer);
+                } catch (CodeCoverageException $e) {
+                    $this->codeCoverageGenerationFailed($e);
+                }
+            }
+
+            if (isset($arguments['coverageHtml'])) {
+                $this->codeCoverageGenerationStart('HTML');
+
+                try {
+                    $writer = new HtmlReport(
+                        $arguments['reportLowUpperBound'],
+                        $arguments['reportHighLowerBound'],
+                        \sprintf(
+                            ' and <a href="https://phpunit.de/">PHPUnit %s</a>',
+                            Version::id()
+                        )
+                    );
+
+                    $writer->process($codeCoverage, $arguments['coverageHtml']);
+
+                    $this->codeCoverageGenerationSucceeded();
+
+                    unset($writer);
+                } catch (CodeCoverageException $e) {
+                    $this->codeCoverageGenerationFailed($e);
+                }
+            }
+
+            if (isset($arguments['coveragePHP'])) {
+                $this->codeCoverageGenerationStart('PHP');
+
+                try {
+                    $writer = new PhpReport;
+                    $writer->process($codeCoverage, $arguments['coveragePHP']);
+
+                    $this->codeCoverageGenerationSucceeded();
+
+                    unset($writer);
+                } catch (CodeCoverageException $e) {
+                    $this->codeCoverageGenerationFailed($e);
+                }
+            }
+
+            if (isset($arguments['coverageText'])) {
+                if ($arguments['coverageText'] === 'php://stdout') {
+                    $outputStream = $this->printer;
+                    $colors       = $arguments['colors'] && $arguments['colors'] !== ResultPrinter::COLOR_NEVER;
+                } else {
+                    $outputStream = new Printer($arguments['coverageText']);
+                    $colors       = false;
+                }
+
+                $processor = new TextReport(
+                    $arguments['reportLowUpperBound'],
+                    $arguments['reportHighLowerBound'],
+                    $arguments['coverageTextShowUncoveredFiles'],
+                    $arguments['coverageTextShowOnlySummary']
+                );
+
+                $outputStream->write(
+                    $processor->process($codeCoverage, $colors)
+                );
+            }
+
+            if (isset($arguments['coverageXml'])) {
+                $this->codeCoverageGenerationStart('PHPUnit XML');
+
+                try {
+                    $writer = new XmlReport(Version::id());
+                    $writer->process($codeCoverage, $arguments['coverageXml']);
+
+                    $this->codeCoverageGenerationSucceeded();
+
+                    unset($writer);
+                } catch (CodeCoverageException $e) {
+                    $this->codeCoverageGenerationFailed($e);
+                }
+            }
+        }
+
+        if ($exit) {
+            if ($result->wasSuccessfulIgnoringWarnings()) {
+                if ($arguments['failOnRisky'] && !$result->allHarmless()) {
+                    exit(self::FAILURE_EXIT);
+                }
+
+                if ($arguments['failOnWarning'] && $result->warningCount() > 0) {
+                    exit(self::FAILURE_EXIT);
+                }
+
+                exit(self::SUCCESS_EXIT);
+            }
+
+            if ($result->errorCount() > 0) {
+                exit(self::EXCEPTION_EXIT);
+            }
+
+            if ($result->failureCount() > 0) {
+                exit(self::FAILURE_EXIT);
+            }
+        }
+
+        return $result;
+    }
+
+    public function setPrinter(ResultPrinter $resultPrinter): void
+    {
+        $this->printer = $resultPrinter;
+    }
+
+    /**
+     * Returns the loader to be used.
+     */
+    public function getLoader(): TestSuiteLoader
+    {
+        if ($this->loader === null) {
+            $this->loader = new StandardTestSuiteLoader;
+        }
+
+        return $this->loader;
+    }
+
+    public function addExtension(Hook $extension): void
+    {
+        $this->extensions[] = $extension;
+    }
+
+    /**
+     * Override to define how to handle a failed loading of
+     * a test suite.
+     */
+    protected function runFailed(string $message): void
+    {
+        $this->write($message . \PHP_EOL);
+
+        exit(self::FAILURE_EXIT);
+    }
+
+    private function createTestResult(): TestResult
+    {
+        return new TestResult;
+    }
+
+    private function write(string $buffer): void
+    {
+        if (\PHP_SAPI !== 'cli' && \PHP_SAPI !== 'phpdbg') {
+            $buffer = \htmlspecialchars($buffer);
+        }
+
+        if ($this->printer !== null) {
+            $this->printer->write($buffer);
+        } else {
+            print $buffer;
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function handleConfiguration(array &$arguments): void
+    {
+        if (isset($arguments['configuration']) &&
+            !$arguments['configuration'] instanceof Configuration) {
+            $arguments['configuration'] = Configuration::getInstance(
+                $arguments['configuration']
+            );
+        }
+
+        $arguments['debug']     = $arguments['debug'] ?? false;
+        $arguments['filter']    = $arguments['filter'] ?? false;
+        $arguments['listeners'] = $arguments['listeners'] ?? [];
+
+        if (isset($arguments['configuration'])) {
+            $arguments['configuration']->handlePHPConfiguration();
+
+            $phpunitConfiguration = $arguments['configuration']->getPHPUnitConfiguration();
+
+            if (isset($phpunitConfiguration['backupGlobals']) && !isset($arguments['backupGlobals'])) {
+                $arguments['backupGlobals'] = $phpunitConfiguration['backupGlobals'];
+            }
+
+            if (isset($phpunitConfiguration['backupStaticAttributes']) && !isset($arguments['backupStaticAttributes'])) {
+                $arguments['backupStaticAttributes'] = $phpunitConfiguration['backupStaticAttributes'];
+            }
+
+            if (isset($phpunitConfiguration['beStrictAboutChangesToGlobalState']) && !isset($arguments['beStrictAboutChangesToGlobalState'])) {
+                $arguments['beStrictAboutChangesToGlobalState'] = $phpunitConfiguration['beStrictAboutChangesToGlobalState'];
+            }
+
+            if (isset($phpunitConfiguration['bootstrap']) && !isset($arguments['bootstrap'])) {
+                $arguments['bootstrap'] = $phpunitConfiguration['bootstrap'];
+            }
+
+            if (isset($phpunitConfiguration['cacheResult']) && !isset($arguments['cacheResult'])) {
+                $arguments['cacheResult'] = $phpunitConfiguration['cacheResult'];
+            }
+
+            if (isset($phpunitConfiguration['cacheResultFile']) && !isset($arguments['cacheResultFile'])) {
+                $arguments['cacheResultFile'] = $phpunitConfiguration['cacheResultFile'];
+            }
+
+            if (isset($phpunitConfiguration['cacheTokens']) && !isset($arguments['cacheTokens'])) {
+                $arguments['cacheTokens'] = $phpunitConfiguration['cacheTokens'];
+            }
+
+            if (isset($phpunitConfiguration['cacheTokens']) && !isset($arguments['cacheTokens'])) {
+                $arguments['cacheTokens'] = $phpunitConfiguration['cacheTokens'];
+            }
+
+            if (isset($phpunitConfiguration['colors']) && !isset($arguments['colors'])) {
+                $arguments['colors'] = $phpunitConfiguration['colors'];
+            }
+
+            if (isset($phpunitConfiguration['convertDeprecationsToExceptions']) && !isset($arguments['convertDeprecationsToExceptions'])) {
+                $arguments['convertDeprecationsToExceptions'] = $phpunitConfiguration['convertDeprecationsToExceptions'];
+            }
+
+            if (isset($phpunitConfiguration['convertErrorsToExceptions']) && !isset($arguments['convertErrorsToExceptions'])) {
+                $arguments['convertErrorsToExceptions'] = $phpunitConfiguration['convertErrorsToExceptions'];
+            }
+
+            if (isset($phpunitConfiguration['convertNoticesToExceptions']) && !isset($arguments['convertNoticesToExceptions'])) {
+                $arguments['convertNoticesToExceptions'] = $phpunitConfiguration['convertNoticesToExceptions'];
+            }
+
+            if (isset($phpunitConfiguration['convertWarningsToExceptions']) && !isset($arguments['convertWarningsToExceptions'])) {
+                $arguments['convertWarningsToExceptions'] = $phpunitConfiguration['convertWarningsToExceptions'];
+            }
+
+            if (isset($phpunitConfiguration['processIsolation']) && !isset($arguments['processIsolation'])) {
+                $arguments['processIsolation'] = $phpunitConfiguration['processIsolation'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnDefect']) && !isset($arguments['stopOnDefect'])) {
+                $arguments['stopOnDefect'] = $phpunitConfiguration['stopOnDefect'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnError']) && !isset($arguments['stopOnError'])) {
+                $arguments['stopOnError'] = $phpunitConfiguration['stopOnError'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnFailure']) && !isset($arguments['stopOnFailure'])) {
+                $arguments['stopOnFailure'] = $phpunitConfiguration['stopOnFailure'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnWarning']) && !isset($arguments['stopOnWarning'])) {
+                $arguments['stopOnWarning'] = $phpunitConfiguration['stopOnWarning'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnIncomplete']) && !isset($arguments['stopOnIncomplete'])) {
+                $arguments['stopOnIncomplete'] = $phpunitConfiguration['stopOnIncomplete'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnRisky']) && !isset($arguments['stopOnRisky'])) {
+                $arguments['stopOnRisky'] = $phpunitConfiguration['stopOnRisky'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnSkipped']) && !isset($arguments['stopOnSkipped'])) {
+                $arguments['stopOnSkipped'] = $phpunitConfiguration['stopOnSkipped'];
+            }
+
+            if (isset($phpunitConfiguration['failOnWarning']) && !isset($arguments['failOnWarning'])) {
+                $arguments['failOnWarning'] = $phpunitConfiguration['failOnWarning'];
+            }
+
+            if (isset($phpunitConfiguration['failOnRisky']) && !isset($arguments['failOnRisky'])) {
+                $arguments['failOnRisky'] = $phpunitConfiguration['failOnRisky'];
+            }
+
+            if (isset($phpunitConfiguration['timeoutForSmallTests']) && !isset($arguments['timeoutForSmallTests'])) {
+                $arguments['timeoutForSmallTests'] = $phpunitConfiguration['timeoutForSmallTests'];
+            }
+
+            if (isset($phpunitConfiguration['timeoutForMediumTests']) && !isset($arguments['timeoutForMediumTests'])) {
+                $arguments['timeoutForMediumTests'] = $phpunitConfiguration['timeoutForMediumTests'];
+            }
+
+            if (isset($phpunitConfiguration['timeoutForLargeTests']) && !isset($arguments['timeoutForLargeTests'])) {
+                $arguments['timeoutForLargeTests'] = $phpunitConfiguration['timeoutForLargeTests'];
+            }
+
+            if (isset($phpunitConfiguration['reportUselessTests']) && !isset($arguments['reportUselessTests'])) {
+                $arguments['reportUselessTests'] = $phpunitConfiguration['reportUselessTests'];
+            }
+
+            if (isset($phpunitConfiguration['strictCoverage']) && !isset($arguments['strictCoverage'])) {
+                $arguments['strictCoverage'] = $phpunitConfiguration['strictCoverage'];
+            }
+
+            if (isset($phpunitConfiguration['ignoreDeprecatedCodeUnitsFromCodeCoverage']) && !isset($arguments['ignoreDeprecatedCodeUnitsFromCodeCoverage'])) {
+                $arguments['ignoreDeprecatedCodeUnitsFromCodeCoverage'] = $phpunitConfiguration['ignoreDeprecatedCodeUnitsFromCodeCoverage'];
+            }
+
+            if (isset($phpunitConfiguration['disallowTestOutput']) && !isset($arguments['disallowTestOutput'])) {
+                $arguments['disallowTestOutput'] = $phpunitConfiguration['disallowTestOutput'];
+            }
+
+            if (isset($phpunitConfiguration['defaultTimeLimit']) && !isset($arguments['defaultTimeLimit'])) {
+                $arguments['defaultTimeLimit'] = $phpunitConfiguration['defaultTimeLimit'];
+            }
+
+            if (isset($phpunitConfiguration['enforceTimeLimit']) && !isset($arguments['enforceTimeLimit'])) {
+                $arguments['enforceTimeLimit'] = $phpunitConfiguration['enforceTimeLimit'];
+            }
+
+            if (isset($phpunitConfiguration['disallowTodoAnnotatedTests']) && !isset($arguments['disallowTodoAnnotatedTests'])) {
+                $arguments['disallowTodoAnnotatedTests'] = $phpunitConfiguration['disallowTodoAnnotatedTests'];
+            }
+
+            if (isset($phpunitConfiguration['beStrictAboutResourceUsageDuringSmallTests']) && !isset($arguments['beStrictAboutResourceUsageDuringSmallTests'])) {
+                $arguments['beStrictAboutResourceUsageDuringSmallTests'] = $phpunitConfiguration['beStrictAboutResourceUsageDuringSmallTests'];
+            }
+
+            if (isset($phpunitConfiguration['verbose']) && !isset($arguments['verbose'])) {
+                $arguments['verbose'] = $phpunitConfiguration['verbose'];
+            }
+
+            if (isset($phpunitConfiguration['reverseDefectList']) && !isset($arguments['reverseList'])) {
+                $arguments['reverseList'] = $phpunitConfiguration['reverseDefectList'];
+            }
+
+            if (isset($phpunitConfiguration['forceCoversAnnotation']) && !isset($arguments['forceCoversAnnotation'])) {
+                $arguments['forceCoversAnnotation'] = $phpunitConfiguration['forceCoversAnnotation'];
+            }
+
+            if (isset($phpunitConfiguration['disableCodeCoverageIgnore']) && !isset($arguments['disableCodeCoverageIgnore'])) {
+                $arguments['disableCodeCoverageIgnore'] = $phpunitConfiguration['disableCodeCoverageIgnore'];
+            }
+
+            if (isset($phpunitConfiguration['registerMockObjectsFromTestArgumentsRecursively']) && !isset($arguments['registerMockObjectsFromTestArgumentsRecursively'])) {
+                $arguments['registerMockObjectsFromTestArgumentsRecursively'] = $phpunitConfiguration['registerMockObjectsFromTestArgumentsRecursively'];
+            }
+
+            if (isset($phpunitConfiguration['executionOrder']) && !isset($arguments['executionOrder'])) {
+                $arguments['executionOrder'] = $phpunitConfiguration['executionOrder'];
+            }
+
+            if (isset($phpunitConfiguration['executionOrderDefects']) && !isset($arguments['executionOrderDefects'])) {
+                $arguments['executionOrderDefects'] = $phpunitConfiguration['executionOrderDefects'];
+            }
+
+            if (isset($phpunitConfiguration['resolveDependencies']) && !isset($arguments['resolveDependencies'])) {
+                $arguments['resolveDependencies'] = $phpunitConfiguration['resolveDependencies'];
+            }
+
+            if (isset($phpunitConfiguration['noInteraction']) && !isset($arguments['noInteraction'])) {
+                $arguments['noInteraction'] = $phpunitConfiguration['noInteraction'];
+            }
+
+            if (isset($phpunitConfiguration['conflictBetweenPrinterClassAndTestdox'])) {
+                $arguments['conflictBetweenPrinterClassAndTestdox'] = true;
+            }
+
+            $groupCliArgs = [];
+
+            if (!empty($arguments['groups'])) {
+                $groupCliArgs = $arguments['groups'];
+            }
+
+            $groupConfiguration = $arguments['configuration']->getGroupConfiguration();
+
+            if (!empty($groupConfiguration['include']) && !isset($arguments['groups'])) {
+                $arguments['groups'] = $groupConfiguration['include'];
+            }
+
+            if (!empty($groupConfiguration['exclude']) && !isset($arguments['excludeGroups'])) {
+                $arguments['excludeGroups'] = \array_diff($groupConfiguration['exclude'], $groupCliArgs);
+            }
+
+            foreach ($arguments['configuration']->getExtensionConfiguration() as $extension) {
+                if ($extension['file'] !== '' && !\class_exists($extension['class'], false)) {
+                    require_once $extension['file'];
+                }
+
+                if (!\class_exists($extension['class'])) {
+                    throw new Exception(
+                        \sprintf(
+                            'Class "%s" does not exist',
+                            $extension['class']
+                        )
+                    );
+                }
+
+                try {
+                    $extensionClass = new \ReflectionClass($extension['class']);
+                    // @codeCoverageIgnoreStart
+                } catch (\ReflectionException $e) {
+                    throw new Exception(
+                        $e->getMessage(),
+                        (int) $e->getCode(),
+                        $e
+                    );
+                }
+                // @codeCoverageIgnoreEnd
+
+                if (!$extensionClass->implementsInterface(Hook::class)) {
+                    throw new Exception(
+                        \sprintf(
+                            'Class "%s" does not implement a PHPUnit\Runner\Hook interface',
+                            $extension['class']
+                        )
+                    );
+                }
+
+                if (\count($extension['arguments']) === 0) {
+                    $extensionObject = $extensionClass->newInstance();
+                } else {
+                    $extensionObject = $extensionClass->newInstanceArgs(
+                        $extension['arguments']
+                    );
+                }
+
+                \assert($extensionObject instanceof Hook);
+
+                $this->addExtension($extensionObject);
+            }
+
+            foreach ($arguments['configuration']->getListenerConfiguration() as $listener) {
+                if ($listener['file'] !== '' && !\class_exists($listener['class'], false)) {
+                    require_once $listener['file'];
+                }
+
+                if (!\class_exists($listener['class'])) {
+                    throw new Exception(
+                        \sprintf(
+                            'Class "%s" does not exist',
+                            $listener['class']
+                        )
+                    );
+                }
+
+                try {
+                    $listenerClass = new \ReflectionClass($listener['class']);
+                    // @codeCoverageIgnoreStart
+                } catch (\ReflectionException $e) {
+                    throw new Exception(
+                        $e->getMessage(),
+                        (int) $e->getCode(),
+                        $e
+                    );
+                }
+                // @codeCoverageIgnoreEnd
+
+                if (!$listenerClass->implementsInterface(TestListener::class)) {
+                    throw new Exception(
+                        \sprintf(
+                            'Class "%s" does not implement the PHPUnit\Framework\TestListener interface',
+                            $listener['class']
+                        )
+                    );
+                }
+
+                if (\count($listener['arguments']) === 0) {
+                    $listener = new $listener['class'];
+                } else {
+                    $listener = $listenerClass->newInstanceArgs(
+                        $listener['arguments']
+                    );
+                }
+
+                $arguments['listeners'][] = $listener;
+            }
+
+            $loggingConfiguration = $arguments['configuration']->getLoggingConfiguration();
+
+            if (isset($loggingConfiguration['coverage-clover']) && !isset($arguments['coverageClover'])) {
+                $arguments['coverageClover'] = $loggingConfiguration['coverage-clover'];
+            }
+
+            if (isset($loggingConfiguration['coverage-crap4j']) && !isset($arguments['coverageCrap4J'])) {
+                $arguments['coverageCrap4J'] = $loggingConfiguration['coverage-crap4j'];
+
+                if (isset($loggingConfiguration['crap4jThreshold']) && !isset($arguments['crap4jThreshold'])) {
+                    $arguments['crap4jThreshold'] = $loggingConfiguration['crap4jThreshold'];
+                }
+            }
+
+            if (isset($loggingConfiguration['coverage-html']) && !isset($arguments['coverageHtml'])) {
+                if (isset($loggingConfiguration['lowUpperBound']) && !isset($arguments['reportLowUpperBound'])) {
+                    $arguments['reportLowUpperBound'] = $loggingConfiguration['lowUpperBound'];
+                }
+
+                if (isset($loggingConfiguration['highLowerBound']) && !isset($arguments['reportHighLowerBound'])) {
+                    $arguments['reportHighLowerBound'] = $loggingConfiguration['highLowerBound'];
+                }
+
+                $arguments['coverageHtml'] = $loggingConfiguration['coverage-html'];
+            }
+
+            if (isset($loggingConfiguration['coverage-php']) && !isset($arguments['coveragePHP'])) {
+                $arguments['coveragePHP'] = $loggingConfiguration['coverage-php'];
+            }
+
+            if (isset($loggingConfiguration['coverage-text']) && !isset($arguments['coverageText'])) {
+                $arguments['coverageText']                   = $loggingConfiguration['coverage-text'];
+                $arguments['coverageTextShowUncoveredFiles'] = $loggingConfiguration['coverageTextShowUncoveredFiles'] ?? false;
+                $arguments['coverageTextShowOnlySummary']    = $loggingConfiguration['coverageTextShowOnlySummary'] ?? false;
+            }
+
+            if (isset($loggingConfiguration['coverage-xml']) && !isset($arguments['coverageXml'])) {
+                $arguments['coverageXml'] = $loggingConfiguration['coverage-xml'];
+            }
+
+            if (isset($loggingConfiguration['plain'])) {
+                $arguments['listeners'][] = new ResultPrinter(
+                    $loggingConfiguration['plain'],
+                    true
+                );
+            }
+
+            if (isset($loggingConfiguration['teamcity']) && !isset($arguments['teamcityLogfile'])) {
+                $arguments['teamcityLogfile'] = $loggingConfiguration['teamcity'];
+            }
+
+            if (isset($loggingConfiguration['junit']) && !isset($arguments['junitLogfile'])) {
+                $arguments['junitLogfile'] = $loggingConfiguration['junit'];
+            }
+
+            if (isset($loggingConfiguration['testdox-html']) && !isset($arguments['testdoxHTMLFile'])) {
+                $arguments['testdoxHTMLFile'] = $loggingConfiguration['testdox-html'];
+            }
+
+            if (isset($loggingConfiguration['testdox-text']) && !isset($arguments['testdoxTextFile'])) {
+                $arguments['testdoxTextFile'] = $loggingConfiguration['testdox-text'];
+            }
+
+            if (isset($loggingConfiguration['testdox-xml']) && !isset($arguments['testdoxXMLFile'])) {
+                $arguments['testdoxXMLFile'] = $loggingConfiguration['testdox-xml'];
+            }
+
+            $testdoxGroupConfiguration = $arguments['configuration']->getTestdoxGroupConfiguration();
+
+            if (isset($testdoxGroupConfiguration['include']) &&
+                !isset($arguments['testdoxGroups'])) {
+                $arguments['testdoxGroups'] = $testdoxGroupConfiguration['include'];
+            }
+
+            if (isset($testdoxGroupConfiguration['exclude']) &&
+                !isset($arguments['testdoxExcludeGroups'])) {
+                $arguments['testdoxExcludeGroups'] = $testdoxGroupConfiguration['exclude'];
+            }
+        }
+
+        $arguments['addUncoveredFilesFromWhitelist']                      = $arguments['addUncoveredFilesFromWhitelist'] ?? true;
+        $arguments['backupGlobals']                                       = $arguments['backupGlobals'] ?? null;
+        $arguments['backupStaticAttributes']                              = $arguments['backupStaticAttributes'] ?? null;
+        $arguments['beStrictAboutChangesToGlobalState']                   = $arguments['beStrictAboutChangesToGlobalState'] ?? null;
+        $arguments['beStrictAboutResourceUsageDuringSmallTests']          = $arguments['beStrictAboutResourceUsageDuringSmallTests'] ?? false;
+        $arguments['cacheResult']                                         = $arguments['cacheResult'] ?? true;
+        $arguments['cacheTokens']                                         = $arguments['cacheTokens'] ?? false;
+        $arguments['colors']                                              = $arguments['colors'] ?? ResultPrinter::COLOR_DEFAULT;
+        $arguments['columns']                                             = $arguments['columns'] ?? 80;
+        $arguments['convertDeprecationsToExceptions']                     = $arguments['convertDeprecationsToExceptions'] ?? true;
+        $arguments['convertErrorsToExceptions']                           = $arguments['convertErrorsToExceptions'] ?? true;
+        $arguments['convertNoticesToExceptions']                          = $arguments['convertNoticesToExceptions'] ?? true;
+        $arguments['convertWarningsToExceptions']                         = $arguments['convertWarningsToExceptions'] ?? true;
+        $arguments['crap4jThreshold']                                     = $arguments['crap4jThreshold'] ?? 30;
+        $arguments['disallowTestOutput']                                  = $arguments['disallowTestOutput'] ?? false;
+        $arguments['disallowTodoAnnotatedTests']                          = $arguments['disallowTodoAnnotatedTests'] ?? false;
+        $arguments['defaultTimeLimit']                                    = $arguments['defaultTimeLimit'] ?? 0;
+        $arguments['enforceTimeLimit']                                    = $arguments['enforceTimeLimit'] ?? false;
+        $arguments['excludeGroups']                                       = $arguments['excludeGroups'] ?? [];
+        $arguments['executionOrder']                                      = $arguments['executionOrder'] ?? TestSuiteSorter::ORDER_DEFAULT;
+        $arguments['executionOrderDefects']                               = $arguments['executionOrderDefects'] ?? TestSuiteSorter::ORDER_DEFAULT;
+        $arguments['failOnRisky']                                         = $arguments['failOnRisky'] ?? false;
+        $arguments['failOnWarning']                                       = $arguments['failOnWarning'] ?? false;
+        $arguments['groups']                                              = $arguments['groups'] ?? [];
+        $arguments['noInteraction']                                       = $arguments['noInteraction'] ?? false;
+        $arguments['processIsolation']                                    = $arguments['processIsolation'] ?? false;
+        $arguments['processUncoveredFilesFromWhitelist']                  = $arguments['processUncoveredFilesFromWhitelist'] ?? false;
+        $arguments['randomOrderSeed']                                     = $arguments['randomOrderSeed'] ?? \time();
+        $arguments['registerMockObjectsFromTestArgumentsRecursively']     = $arguments['registerMockObjectsFromTestArgumentsRecursively'] ?? false;
+        $arguments['repeat']                                              = $arguments['repeat'] ?? false;
+        $arguments['reportHighLowerBound']                                = $arguments['reportHighLowerBound'] ?? 90;
+        $arguments['reportLowUpperBound']                                 = $arguments['reportLowUpperBound'] ?? 50;
+        $arguments['reportUselessTests']                                  = $arguments['reportUselessTests'] ?? true;
+        $arguments['reverseList']                                         = $arguments['reverseList'] ?? false;
+        $arguments['resolveDependencies']                                 = $arguments['resolveDependencies'] ?? true;
+        $arguments['stopOnError']                                         = $arguments['stopOnError'] ?? false;
+        $arguments['stopOnFailure']                                       = $arguments['stopOnFailure'] ?? false;
+        $arguments['stopOnIncomplete']                                    = $arguments['stopOnIncomplete'] ?? false;
+        $arguments['stopOnRisky']                                         = $arguments['stopOnRisky'] ?? false;
+        $arguments['stopOnSkipped']                                       = $arguments['stopOnSkipped'] ?? false;
+        $arguments['stopOnWarning']                                       = $arguments['stopOnWarning'] ?? false;
+        $arguments['stopOnDefect']                                        = $arguments['stopOnDefect'] ?? false;
+        $arguments['strictCoverage']                                      = $arguments['strictCoverage'] ?? false;
+        $arguments['testdoxExcludeGroups']                                = $arguments['testdoxExcludeGroups'] ?? [];
+        $arguments['testdoxGroups']                                       = $arguments['testdoxGroups'] ?? [];
+        $arguments['timeoutForLargeTests']                                = $arguments['timeoutForLargeTests'] ?? 60;
+        $arguments['timeoutForMediumTests']                               = $arguments['timeoutForMediumTests'] ?? 10;
+        $arguments['timeoutForSmallTests']                                = $arguments['timeoutForSmallTests'] ?? 1;
+        $arguments['verbose']                                             = $arguments['verbose'] ?? false;
+    }
+
+    private function processSuiteFilters(TestSuite $suite, array $arguments): void
+    {
+        if (!$arguments['filter'] &&
+            empty($arguments['groups']) &&
+            empty($arguments['excludeGroups'])) {
+            return;
+        }
+
+        $filterFactory = new Factory;
+
+        if (!empty($arguments['excludeGroups'])) {
+            $filterFactory->addFilter(
+                new \ReflectionClass(ExcludeGroupFilterIterator::class),
+                $arguments['excludeGroups']
+            );
+        }
+
+        if (!empty($arguments['groups'])) {
+            $filterFactory->addFilter(
+                new \ReflectionClass(IncludeGroupFilterIterator::class),
+                $arguments['groups']
+            );
+        }
+
+        if ($arguments['filter']) {
+            $filterFactory->addFilter(
+                new \ReflectionClass(NameFilterIterator::class),
+                $arguments['filter']
+            );
+        }
+
+        $suite->injectFilter($filterFactory);
+    }
+
+    private function writeMessage(string $type, string $message): void
+    {
+        if (!$this->messagePrinted) {
+            $this->write("\n");
+        }
+
+        $this->write(
+            \sprintf(
+                "%-15s%s\n",
+                $type . ':',
+                $message
+            )
+        );
+
+        $this->messagePrinted = true;
+    }
+
+    /**
+     * @template T as Printer
+     *
+     * @param class-string<T> $class
+     *
+     * @return T
+     */
+    private function createPrinter(string $class, array $arguments): Printer
+    {
+        return new $class(
+            (isset($arguments['stderr']) && $arguments['stderr'] === true) ? 'php://stderr' : null,
+            $arguments['verbose'],
+            $arguments['colors'],
+            $arguments['debug'],
+            $arguments['columns'],
+            $arguments['reverseList']
+        );
+    }
+
+    private function codeCoverageGenerationStart(string $format): void
+    {
+        $this->printer->write(
+            \sprintf(
+                "\nGenerating code coverage report in %s format ... ",
+                $format
+            )
+        );
+
+        Timer::start();
+    }
+
+    private function codeCoverageGenerationSucceeded(): void
+    {
+        $this->printer->write(
+            \sprintf(
+                "done [%s]\n",
+                Timer::secondsToTimeString(Timer::stop())
+            )
+        );
+    }
+
+    private function codeCoverageGenerationFailed(\Exception $e): void
+    {
+        $this->printer->write(
+            \sprintf(
+                "failed [%s]\n%s\n",
+                Timer::secondsToTimeString(Timer::stop()),
+                $e->getMessage()
+            )
+        );
     }
 }


### PR DESCRIPTION
This is definitely a hack and a maintenance nightmare - but it works for now.

We can look for a better alternative later, see https://github.com/wizaplace/phpunit-slicer/issues/7